### PR TITLE
Build cleanly on rust 1.1 nightly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 env:
   global:
     - secure: a0aZLlsuJdEsS/94pcCIr9D0WPdoawBH/dCz39/RAxTcT+g56YzlU4RtjyVqnlo92qPYAs11r/CrAGKCJHS92GIESUziA0ZDwgkKpPerJYl/OcTL612ArARO02UDNsD67y+gAOZF5xrt/Sppro65oIqKVYRwY+HKcESlQqp9/b0=
-install:
-  - curl -s https://static.rust-lang.org/rustup.sh | sudo sh - 
-  - export LD_LIBRARY_PATH=$PWD/target/:/usr/local/lib/
+language: rust
+rust:
+  - nightly
 script:
+  - cargo clean
   - cargo build --verbose
   - cargo test --verbose
-  - make clean doc
+  - cargo doc --verbose
 after_script:
   - curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh
 notifications:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ build = "build.rs"
 
 name = "knuckle"
 path = "src/lib.rs"
+
+[dependencies]
+libc = "0.1.8"

--- a/build.rs
+++ b/build.rs
@@ -1,18 +1,8 @@
-#![feature(fs, path, process, core)]
-
-use std::fs::PathExt;
 use std::path::Path;
 use std::process::Command;
 
 fn main() {
     let out_dir = env!("OUT_DIR");
-
-    println!("cargo:rustc-flags=-L {} -l tweetnacl:static", out_dir);
-
-    if Path::new(format!("{}/libtweetnacl.a", out_dir).as_slice()).exists() {
-        println!("Nothing to do...");
-        return;
-    }
 
     Command::new("cc")
         .arg("src/lib/tweetnacl.c")
@@ -20,7 +10,7 @@ fn main() {
         .arg("-fPIC")
         .arg("-Isrc/lib/")
         .arg("-o")
-        .arg(format!("{}/tweetnacl.o", out_dir).as_slice())
+        .arg(format!("{}/tweetnacl.o", out_dir))
         .status()
         .unwrap();
 
@@ -31,4 +21,7 @@ fn main() {
         .current_dir(Path::new(out_dir))
         .status()
         .unwrap();
+
+    println!("cargo:rustc-link-search=native={}", out_dir);
+    println!("cargo:rustc-link-lib=static=tweetnacl");
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -8,7 +8,7 @@
 //! let digest1 = hash(b"this is my message");
 //! let digest2 = hash(b"this is your message");
 //!
-//! assert!(digest1.as_slice() != digest2.as_slice());
+//! assert!(&digest1[..] != &digest2[..]);
 //! ```
 
 use bindings::*;
@@ -43,5 +43,5 @@ fn test_hash_sanity() {
                     0x1d, 0x13, 0x8b, 0xc7, 0xaa, 0xd1, 0xaf, 0x3e,
                     0xf7, 0xbf, 0xd5, 0xec, 0x64, 0x6d, 0x6c, 0x28];
 
-    assert_eq!(hash(&x).as_slice(), expected.as_slice());
+    assert_eq!(&hash(&x)[..], &expected[..]);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
 #![crate_name = "knuckle"]
 #![crate_type = "lib"]
 
-#![feature(core, collections, libc)]
-
+#![feature(slice_bytes, vec_push_all)]
 //#![deny(missing_doc)]
 
 //! `knuckle` is an opinionated Rust language interface to the
@@ -35,19 +34,15 @@ pub use bindings::*;
 
 /// Exposes direct Rust bindings to the C NaCl interface.
 #[allow(dead_code)]
-#[stable]
 pub mod bindings;
 
 /// Provides authenticated asymmetric key cryptography operations.
-#[stable]
 pub mod cryptobox;
 
 /// Simple interface to strong cryptographic hash function.
-#[stable]
 pub mod hash;
 
 /// Provides authenticated symmetric key cryptography operations.
-#[stable]
 pub mod secretbox;
 
 /// Provides simple interface to generate and validate digital signatures.

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -6,7 +6,7 @@ pub const KEY_BYTES: usize = 32;
 
 pub type SecretKey = [u8; KEY_BYTES];
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Stream {
     pub sk: SecretKey
 }


### PR DESCRIPTION
Change travis file to use language: rust to automatically install rust
nightly.
Change `as_slice()` to reference notation.
Use crates.io libc instead of `#![feature(libc)]`.
Swap argument order on `slice::bytes::copy_memory()` to src, dest.
Fix linking error in build.rs.

Things I forgot to mention in the commit message:
Derive Clone in any place that Copy is derived.
Use `a..b` notation in place of `range(a, b)`.
Use cargo to build docs.

After this, the makefile is (I think) obsolete, since everything is handled by cargo.