### PR TITLE
Compile on Rust 1.1.0 stable.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![crate_name = "knuckle"]
 #![crate_type = "lib"]
 
-#![feature(slice_bytes, vec_push_all)]
 //#![deny(missing_doc)]
 
 //! `knuckle` is an opinionated Rust language interface to the

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -20,7 +20,7 @@
 
 use bindings::*;
 
-use std::slice::bytes::copy_memory;
+use std::ptr::copy_nonoverlapping;
 
 /// Number of bytes in the sign public key
 pub const PUBKEY_BYTES: usize = 32;
@@ -85,7 +85,7 @@ impl SignedMsg {
         let PublicKey(pk) = self.pk;
         let mut buf = pk.to_vec();
 
-        buf.push_all(&self.signed);
+        buf.extend(self.signed.iter().cloned());
 
         buf
     }
@@ -102,7 +102,7 @@ impl SignedMsg {
         let mut pk = [0u8; PUBKEY_BYTES];
         let signed = &msg[PUBKEY_BYTES..];
 
-        copy_memory(&msg[0 .. PUBKEY_BYTES], &mut pk);
+        unsafe { copy_nonoverlapping(msg.as_ptr(), pk.as_mut_ptr(), PUBKEY_BYTES); }
 
         Some(SignedMsg { pk: PublicKey(pk), signed: signed.to_vec() })
     }


### PR DESCRIPTION
In 1.2.0, it may be possible to replace the code like `foo.extend(bar.iter().cloned())` with `foo.extend(&bar)`.

If/when `copy_memory` is stabilized, that part of this commit could be reverted. Another safer approach for right now could be to implement your own `copy_memory` in terms of `copy_nonoverlapping` to reduce the number of `unsafe` blocks.
